### PR TITLE
linearization entity

### DIFF
--- a/icd_api/icd_api.py
+++ b/icd_api/icd_api.py
@@ -2,6 +2,7 @@ import time
 import urllib.parse
 from datetime import datetime
 import os
+from typing import Union
 
 import requests
 from dataclasses import dataclass
@@ -137,8 +138,10 @@ class Api:
                 raise ValueError(f"Api.get_residual_codes -- unexpected Response {r.status_code}")
         return results
 
-    def get_entity(self, entity_id: str) -> ICDEntity:
+    def get_entity(self, entity_id: str) -> Union[ICDEntity, None]:
         """
+        get the response from ~/icd/entity/{entity_id}
+
         :param entity_id: id of an ICD-11 foundation entity
         :type entity_id: int
         :return: information on the specified ICD-11 foundation entity
@@ -157,9 +160,9 @@ class Api:
     def get_linearization_entity(self,
                                  entity_id: str,
                                  linearization_name: str,
-                                 include: str = None) -> ICDLookup or None:
+                                 include: str = None) -> Union[ICDLookup, None]:
         """
-        get the response from ~/icd/release/11/2023-01/mms/1376721186
+        get the response from ~/icd/release/11/2023-01/{linearization_name}/{entity_id}
 
         :param entity_id: id of an ICD-11 foundation entity
         :type entity_id: int
@@ -187,6 +190,8 @@ class Api:
 
     def get_linearization_descendent_ids(self, entity_id: str, linearization_name: str) -> list or None:
         """
+        get all descendents of the provided entity, in the context of the provided linearization
+
         :param entity_id: id of an ICD-11 foundation entity
         :type entity_id: int
         :param linearization_name: id of an ICD-11 linearization (eg mms)
@@ -199,6 +204,24 @@ class Api:
                                             include="descendant")
         if obj:
             return obj.descendant_ids
+        return None
+
+    def get_linearization_ancestor_ids(self, entity_id: str, linearization_name: str) -> list or None:
+        """
+        get all ancestors of the provided entity, in the context of the provided linearization
+
+        :param entity_id: id of an ICD-11 foundation entity
+        :type entity_id: int
+        :param linearization_name: id of an ICD-11 linearization (eg mms)
+        :type linearization_name: str
+        :return: list of descendant entity_ids
+        :rtype: list
+        """
+        obj = self.get_linearization_entity(entity_id=entity_id,
+                                            linearization_name=linearization_name,
+                                            include="ancestor")
+        if obj:
+            return obj.ancestor_ids
         return None
 
     def get_entity_full(self, entity_id: str) -> ICDEntity:

--- a/icd_api/icd_entity.py
+++ b/icd_api/icd_entity.py
@@ -88,6 +88,9 @@ class ICDEntity:
 
     @classmethod
     def from_api(cls, entity_id: str, response_data: dict):
+        if response_data is None:
+            return None
+
         uri = response_data["@id"]
         uri_entity_id = response_data["@id"]
         response_data["entity_id"] = get_entity_id(uri=uri)

--- a/icd_api/icd_lookup.py
+++ b/icd_api/icd_lookup.py
@@ -155,6 +155,8 @@ class ICDLookup:
         """
         Use the json response data from a lookup call to instantiate and return an ICDLookup object
         """
+        if response_data is None:
+            return None
         params, other = get_params_dicts(response_data=response_data, known_keys=lookup_known_keys)
         params["response_id_uri"] = response_data.get("@id", "")
         obj = cls(**params, other=other, request_uri=request_uri)

--- a/icd_api/icd_lookup.py
+++ b/icd_api/icd_lookup.py
@@ -171,7 +171,7 @@ class ICDLookup:
         # use foundationReference as a default key, fall back on linearizationReference --
         # both should be there, and both should have the same trailing entity_id
         uris = [uri.get("foundationReference", uri["linearizationReference"])
-                for uri in self.foundation_child_elsewhere]
+                for uri in self.foundation_child_elsewhere or []]
         return [uri.split("/")[-1] for uri in uris]
 
     @property

--- a/tests/test_icd_api.py
+++ b/tests/test_icd_api.py
@@ -76,7 +76,7 @@ def test_set_linearization(api):
 
 def test_get_entity_linearization(api):
     linearization_name = "mms"
-    linearization = api.get_entity_linearization(entity_id=1630407678, linearization_name=linearization_name)
+    linearization = api.get_entity_linearization_releases(entity_id=1630407678, linearization_name=linearization_name)
     assert linearization
 
 

--- a/tests/test_icd_api.py
+++ b/tests/test_icd_api.py
@@ -3,7 +3,7 @@ import os
 import pytest as pytest
 from dotenv import load_dotenv, find_dotenv
 
-from icd_api import Api, ICDEntity, ICDLookup
+from icd_api import Api, ICDEntity, ICDLookup, get_entity_id
 
 load_dotenv(find_dotenv())
 
@@ -32,6 +32,28 @@ def test_get_entity(api):
 
     for child in entity.child_ids:
         print(child)
+
+
+def test_get_linearization_entity(api):
+    entity = api.get_linearization_entity(entity_id="1376721186", linearization_name="mms")
+    assert entity
+    assert "136616595" not in entity.child_ids
+
+
+def test_get_linearization_descendants(api):
+    descendants = api.get_linearization_descendent_ids(entity_id="1376721186", linearization_name="mms")
+    assert descendants
+
+
+def test_get_linearization_ancestors(api):
+    ancestors = api.get_linearization_ancestor_ids(entity_id="1376721186", linearization_name="mms")
+    assert ancestors
+
+
+def test_get_foundation_child_elsewhere(api):
+    linearization_entity = api.get_linearization_entity(entity_id="1376721186", linearization_name="mms")
+    assert linearization_entity
+    assert "136616595" in linearization_entity.foundation_child_elsewhere_ids
 
 
 def test_get_entity_full(api):
@@ -81,6 +103,14 @@ def test_lookup(api):
     entity = api.lookup(foundation_uri=foundation_uri)
     assert isinstance(entity, ICDLookup)
     assert entity.request_type == "lookup"
+
+
+def test_lookup_residual(api):
+    foundation_uri = "http://id.who.int/icd/entity/1008196289"
+    entity = api.lookup(foundation_uri=foundation_uri)
+    assert isinstance(entity, ICDLookup)
+    assert entity.is_residual
+    assert entity.residual == "unspecified"
 
 
 def test_search_linearization(api):


### PR DESCRIPTION
adding a new functions Api.get_linearization_entity, get_descendant_ids, get_ancestor_ids, with unit tests

also, 
- adding descendant and ancestor id props to ICDLookup
- adding a helper function get_request to clean up duplicate api response handling
- renamed api.get_entity_linearization_releases for clarity
