### PR TITLE
Linearization refactor

### DIFF
--- a/icd_api/icd_api.py
+++ b/icd_api/icd_api.py
@@ -14,11 +14,24 @@ from icd_api.icd_lookup import ICDLookup
 
 @dataclass
 class Linearisation:
-    context: str             # url to context
-    oid: str                 # url to linearization
-    title: dict              # language (str) and value (str)
-    latest_release_uri: str  # url to latest release
-    releases: list           # list of urls to prior releases
+    context: str                # url to context
+    oid: str                    # url to linearization
+    title: dict                 # language (str) and value (str)
+    latest_release_uri: str     # url to latest release
+    current_release_uri: str    # id of the current release
+    releases: list              # list of urls to prior releases
+    base_url: str
+
+    def uri_to_id(self, uri: str):
+        return uri.removeprefix(f"{self.base_url}/release/11/").removesuffix("/mms")
+
+    @property
+    def release_ids(self):
+        return [self.uri_to_id(uri) for uri in self.releases]
+
+    @property
+    def current_release_id(self):
+        return self.uri_to_id(self.current_release_uri)
 
 
 class Api:
@@ -114,9 +127,9 @@ class Api:
         return headers
 
     @property
-    def latest_release_id(self):
+    def current_release_id(self):
         if self.linearization:
-            return self.linearization.latest_release_uri.split("/")[-2]
+            return self.linearization.current_release_id
         else:
             return "2023-01"
 
@@ -148,8 +161,8 @@ class Api:
         get Y-code and Z-code information for the provided entity, if they exist
         """
         uris = {
-            "Y": f"{self.base_url}/release/11/{self.latest_release_id}/{linearization_name}/{entity_id}/other",
-            "Z": f"{self.base_url}/release/11/{self.latest_release_id}/{linearization_name}/{entity_id}/unspecified"
+            "Y": f"{self.base_url}/release/11/{self.current_release_id}/{linearization_name}/{entity_id}/other",
+            "Z": f"{self.base_url}/release/11/{self.current_release_id}/{linearization_name}/{entity_id}/unspecified"
         }
         results = {"Y": None, "Z": None}
         for key, uri in uris.items():
@@ -172,8 +185,8 @@ class Api:
         :rtype: ICDEntity
         """
         uri = f"{self.base_url}/entity/{entity_id}"
-        if self.linearization and self.linearization.latest_release_uri:
-            uri += f"?releaseId={self.linearization.latest_release_uri}"
+        if self.linearization and self.current_release_id:
+            uri += f"?releaseId={self.current_release_id}"
 
         response_data = self.get_request(uri=uri)
         return ICDEntity.from_api(entity_id=str(entity_id), response_data=response_data)
@@ -194,7 +207,7 @@ class Api:
         :return: linearization-specific information on the specified ICD-11 entity
         :rtype: ICDLookup
         """
-        uri = f"{self.base_url}/release/11/{self.latest_release_id}/{linearization_name}/{entity_id}"
+        uri = f"{self.base_url}/release/11/{self.current_release_id}/{linearization_name}/{entity_id}"
         if include:
             if include.lower() not in ["ancestor", "descendant"]:
                 raise ValueError(f"Unexpected include value '{include}' (expected 'ancestor' or 'descendant')")
@@ -341,20 +354,26 @@ class Api:
         :return: basic information on the linearization together with the list of available releases
         :rtype: linearization
         """
-        if release_id:
-            uri = f"{self.base_url}/release/11/{release_id}/{linearization_name}"
-        else:
-            uri = f"{self.base_url}/release/11/{linearization_name}"
+        uri = f"{self.base_url}/release/11/{linearization_name}"
+        all_releases = self.get_request(uri=uri)
 
-        r = requests.get(uri, headers=self.headers, verify=False)
-        results = r.json()
         linearization = Linearisation(
-            context=results["@context"],
-            oid=results["@id"],
-            title=results["title"],
-            latest_release_uri=results["latestRelease"],
-            releases=results["release"],
+            context=all_releases["@context"],
+            oid=all_releases["@id"],
+            title=all_releases["title"],
+            latest_release_uri=all_releases["latestRelease"],
+            current_release_uri=all_releases["latestRelease"],
+            releases=all_releases["release"],
+            base_url=self.base_url.replace("https://", "http://"),
         )
+
+        if release_id:
+            # make sure the provided release_id is valid
+            release_ids = linearization.release_ids
+            if release_id not in release_ids:
+                raise ValueError(f"release_id {release_id} not in available releases {','.join(release_ids)}")
+            linearization.current_release_uri = f"{linearization.base_url}/release/11/{release_id}/{linearization_name}"
+
         self.linearization = linearization
         return linearization
 
@@ -439,7 +458,7 @@ class Api:
             uri = f"{self.base_url}/release/10/{code}"
         else:
             quoted_code = urllib.parse.quote(code, safe="")
-            uri = f"{self.base_url}/release/11/{self.latest_release_id}/mms/codeinfo/{quoted_code}?flexiblemode=true"
+            uri = f"{self.base_url}/release/11/{self.current_release_id}/mms/codeinfo/{quoted_code}?flexiblemode=true"
         response_data = self.get_request(uri=uri)
         return response_data
 
@@ -456,7 +475,7 @@ class Api:
         is aggregated to and then returns that entity.
         """
         quoted_url = urllib.parse.quote(foundation_uri, safe='')
-        uri = f"{self.base_url}/release/11/{self.latest_release_id}/mms/lookup?foundationUri={quoted_url}"
+        uri = f"{self.base_url}/release/11/{self.current_release_id}/mms/lookup?foundationUri={quoted_url}"
         response_data = self.get_request(uri=uri)
         entity = ICDLookup.from_api(request_uri=foundation_uri, response_data=response_data)
         return entity
@@ -465,7 +484,7 @@ class Api:
         """
         get the response from ~/icd/release/11/2023-01/{linearization_name}/{search_string}
         """
-        uri = f"{self.base_url}/release/11/{self.latest_release_id}/mms/search?q={search_string}"
+        uri = f"{self.base_url}/release/11/{self.current_release_id}/mms/search?q={search_string}"
         results = self.search(uri=uri)
         return results["destinationEntities"]
 

--- a/icd_api/icd_api.py
+++ b/icd_api/icd_api.py
@@ -196,7 +196,7 @@ class Api:
                                  linearization_name: str,
                                  include: str = None) -> Union[ICDLookup, None]:
         """
-        get the response from ~/icd/release/11/2023-01/{linearization_name}/{entity_id}
+        get the response from ~/icd/release/11/{release_id}/{linearization_name}/{entity_id}
 
         :param entity_id: id of an ICD-11 foundation entity
         :type entity_id: int
@@ -357,6 +357,9 @@ class Api:
         uri = f"{self.base_url}/release/11/{linearization_name}"
         all_releases = self.get_request(uri=uri)
 
+        # Note: the endpoint responds with http urls of all releases which feed into other properties -
+        #       this local `linearization_base_url` definition safeguards against self.base_url values that are https
+        linearization_base_url = self.base_url.replace("https://", "http://")
         linearization = Linearisation(
             context=all_releases["@context"],
             oid=all_releases["@id"],
@@ -364,7 +367,7 @@ class Api:
             latest_release_uri=all_releases["latestRelease"],
             current_release_uri=all_releases["latestRelease"],
             releases=all_releases["release"],
-            base_url=self.base_url.replace("https://", "http://"),
+            base_url=linearization_base_url,
         )
 
         if release_id:
@@ -482,7 +485,7 @@ class Api:
 
     def search_linearization(self, search_string: str):
         """
-        get the response from ~/icd/release/11/2023-01/{linearization_name}/{search_string}
+        get the response from ~/icd/release/11/{release_id}/{linearization_name}/{search_string}
         """
         uri = f"{self.base_url}/release/11/{self.current_release_id}/mms/search?q={search_string}"
         results = self.search(uri=uri)

--- a/icd_api/icd_lookup.py
+++ b/icd_api/icd_lookup.py
@@ -207,6 +207,15 @@ class ICDLookup:
         return [get_entity_id(uri) for uri in self.ancestor or []]
 
     @property
+    def index_term_uris(self):
+        foundation_refs = [it for it in self.index_term if "foundationReference" in it.keys()]
+        return [fr["foundationReference"] for fr in foundation_refs]
+
+    @property
+    def index_term_ids(self):
+        return [get_entity_id(uri) for uri in self.index_term_uris]
+
+    @property
     def node_color(self) -> str:
         if self.code:
             return "blue"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ tests_require = [
 
 setup(
     name='icd-api',
-    version="0.0.2",
+    version="0.0.3",
     description='',
     url='https://github.com/mrreband/icd-api',
     packages=['icd_api'],

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ tests_require = [
 
 setup(
     name='icd-api',
-    version="0.0.3",
+    version="0.0.4",
     description='',
     url='https://github.com/mrreband/icd-api',
     packages=['icd_api'],

--- a/tests/test_icd_api.py
+++ b/tests/test_icd_api.py
@@ -16,8 +16,16 @@ def api():
 
 
 def test_api(api):
-    api.set_linearization("mms")
     assert api
+    assert api.current_release_id == "2023-01"
+
+
+def test_set_linearization():
+    # create a separate Api object so as to not contaminate the fixture
+    test = Api()
+    linearization = test.set_linearization("mms")
+    assert linearization
+    assert test.current_release_id == "2024-01"
 
 
 def test_get_all_children(api):
@@ -65,13 +73,6 @@ def test_get_entity_full(api):
 def test_search_entities(api):
     search_results = api.search_entities(search_string="diabetes")
     assert search_results
-
-
-def test_set_linearization(api):
-    # are there any valid linearizations besides 'mms'?
-    linearization_name = "mms"
-    linearization = api.set_linearization(linearization_name=linearization_name)
-    assert linearization
 
 
 def test_get_entity_linearization(api):

--- a/tests/test_icd_api.py
+++ b/tests/test_icd_api.py
@@ -11,7 +11,7 @@ load_dotenv(find_dotenv())
 @pytest.fixture(scope="session")
 def api():
     _api = Api()
-    _api.set_linearization("mms")
+    _api.set_linearization("mms", release_id="2023-01")
     return _api
 
 

--- a/tests/test_icd_api.py
+++ b/tests/test_icd_api.py
@@ -3,12 +3,12 @@ import os
 import pytest as pytest
 from dotenv import load_dotenv, find_dotenv
 
-from icd_api import Api, ICDEntity, ICDLookup, get_entity_id
+from icd_api import Api, ICDLookup
 
 load_dotenv(find_dotenv())
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def api():
     _api = Api()
     _api.set_linearization("mms")
@@ -132,10 +132,8 @@ def test_get_residual(api):
     assert results["Z"] is None
 
 
-def test_missing_entities():
+def test_missing_entities(api):
     """these were missing from the entities output by Api.get_ancestors - check that the api returns 404 for each"""
-    api = Api()
-    api.set_linearization("mms")
     entity_ids = [1000664379, 1029251439, 1059449428, 1076215290, 1076641430, 1104895717, 1110925902, 1117344084,
                   1130046240, 1147241349, 1219708494, 1233380430, 1249767098, 1252104698, 1252530838, 1274104313,
                   1278087668, 1295619984, 1314209579, 1324098793, 1329167995, 1367002461, 137053351, 1377008485,


### PR DESCRIPTION
Cleanup and expand on the Linearization class 
- can now get all release_ids, latest_release_uri and id, current_release_uri and id
- when calling `Api.set_linearization`, default to the latest release if no release_id is specified
- adding Api properties for indexTerm uris and ids

Also, from the original PR:
- check if the connection is available when instantiating the Api object
- increment patch version
