### PR TITLE
Requests cache

### DIFF
--- a/icd_api/icd_api.py
+++ b/icd_api/icd_api.py
@@ -1,11 +1,12 @@
-import time
-import urllib.parse
+from dataclasses import dataclass
 from datetime import datetime
 import os
+import time
 from typing import Union
+import urllib.parse
 
 import requests
-from dataclasses import dataclass
+import requests_cache
 
 from icd_api.icd_util import get_foundation_uri
 from icd_api.icd_entity import ICDEntity
@@ -37,13 +38,13 @@ class Linearisation:
 class Api:
     def __init__(self):
         self.base_url = os.environ.get("BASE_URL")
-        self.session = requests.Session()
+        self.session = self.get_session()
         self.check_connection()
 
         self.token_endpoint = os.environ.get("TOKEN_ENDPOINT")
         self.client_id = os.environ.get("CLIENT_ID")
         self.client_secret = os.environ.get("CLIENT_SECRET")
-        self.linearization = None  # type: Linearisation or None
+        self.linearization = None  # type: Union[Linearisation, None]
         self.throttled = False
 
         if self.use_auth_token:
@@ -52,6 +53,14 @@ class Api:
         else:
             self.cached_token_path = ""
             self.token = ""
+
+    @staticmethod
+    def get_session():
+        requests_cache_file = os.getenv("REQUESTS_CACHE_FILE")
+        if requests_cache_file:
+            return requests_cache.CachedSession(requests_cache_file)
+        else:
+            return requests.session()
 
     def check_connection(self):
         """
@@ -62,6 +71,10 @@ class Api:
             self.session.get(swagger_endpoint)
         except requests.exceptions.ConnectionError:
             raise ConnectionError(f"Cannot connect to BASE_URL {self.base_url}") from None
+
+    @property
+    def use_cache(self):
+        return isinstance(self.session, requests_cache.CachedSession)
 
     @property
     def token_is_valid(self) -> bool:

--- a/icd_api/icd_api.py
+++ b/icd_api/icd_api.py
@@ -23,8 +23,9 @@ class Linearisation:
     releases: list              # list of urls to prior releases
     base_url: str
 
-    def uri_to_id(self, uri: str):
-        return uri.removeprefix(f"{self.base_url}/release/11/").removesuffix("/mms")
+    @staticmethod
+    def uri_to_id(uri: str):
+        return uri.split("/")[-2]
 
     @property
     def release_ids(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 requests==2.28.1
 pytest==7.2.0
 python-dotenv==0.21.0
+requests-cache==1.2.0
 
 ## others
 attrs==22.2.0

--- a/tests/test_icd_api.py
+++ b/tests/test_icd_api.py
@@ -155,5 +155,22 @@ def test_missing_entities(api):
         assert test is None
 
 
+def test_cache_nocache():
+    # api with no cache
+    os.environ["REQUESTS_CACHE_FILE"] = ""
+    api = Api()
+    assert api.use_cache is False
+
+    # api with cache
+    os.environ["REQUESTS_CACHE_FILE"] = "sure why not"
+    api = Api()
+    assert api.use_cache is True
+
+    # cleanup (del bc it has a lock on the sqlite file)
+    del api
+    if os.path.exists("sure why not.sqlite"):
+        os.remove("sure why not.sqlite")
+
+
 if __name__ == '__main__':
     pytest.main(["test_icd_api.py"])


### PR DESCRIPTION
Adding basic functionality for `requests-cache` package:

- uses the default `sqlite` backend
- only caches if the environment variable "REQUESTS_CACHE_FILE" is present
- added a unit test 

also reorganizing imports at the top of `icd_api.py`
